### PR TITLE
add meetup component with API call

### DIFF
--- a/src/components/meetup.js
+++ b/src/components/meetup.js
@@ -1,0 +1,37 @@
+import React, { Fragment, useState, useEffect } from "react"
+
+const MeetUp = () => {
+  const [events, setEvents] = useState([])
+
+  const corsAPI = "https://cors-anywhere.herokuapp.com/"
+  const meetupURL =
+    "https://www.meetup.com/Syracuse-Software-Development-Meetup/events/json/"
+
+  useEffect(() => {
+    fetch(corsAPI + meetupURL, {
+      method: 'GET',
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+    }).then(res => {
+      res.json().then((res) => {
+        console.log(res)
+        setEvents(res)
+      })
+    })
+  }, [])
+
+  return (
+    <div>
+      <h1>Upcoming Events</h1>
+
+      {events &&
+        events.map((event, index) =>
+          <Fragment key={index}>
+            <p>{event.title}</p>
+            <p>{event.descr}</p>
+          </Fragment>
+        )}
+    </div>
+  )
+}
+
+export default MeetUp


### PR DESCRIPTION
Added a meetup component that makes a call to an API to get the information for upcoming events. I needed to use an additional cors API to get access to the data, otherwise it was inaccessible. It's just one solution to getting the data, though it may just be a temporary one. I am getting the data from Syracuse Software Meetup, and currently there are no Code for Syracuse meetings listed. Once they become available, I think I will be able to filter out the Code for Syracuse events by title, put them into a new array, and then only display the first element, or all of them depending on how much we want to show.

I'm sure I can find a library/libraries to help us with formatting the event dates too.